### PR TITLE
Escape XML entities in ICU replacements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "t-i18n",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t-i18n",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Simple, standards-based localization",
   "author": "Mitch Cohen <mitch.cohen@me.com>",
   "repository": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,7 +27,19 @@ export function Plural(pluralizeFor: string, options: PluralOptions): string {
 			("\tother{" + other + "}}");
 }
 
-export const splitReplacements = <X>(replacements: AnyReplacements<X>): [IcuReplacements, XmlReplacements<X>] => {
+const xmlEscapes: { [key: string]: string } = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	"\"": "&quot;",
+	"'": '&#39;'
+};
+
+const escapeXml = (str: string) => (
+	str.replace(/[&<>"']/g, (match) => xmlEscapes[match])
+);
+
+export const splitAndEscapeReplacements = <X>(replacements: AnyReplacements<X>): [IcuReplacements, XmlReplacements<X>] => {
 	const icu: Mutable<IcuReplacements> = {};
 	const xml: Mutable<XmlReplacements<X>> = {};
 	for (const key in replacements) {
@@ -35,6 +47,8 @@ export const splitReplacements = <X>(replacements: AnyReplacements<X>): [IcuRepl
 			const value = replacements[key];
 			if (typeof value === "function") {
 				xml[key] = value;
+			} else if (typeof value === "string") {
+				icu[key] = escapeXml(value);
 			} else {
 				icu[key] = value;
 			}

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -6,7 +6,7 @@ import parseXml from "./xml";
 
 /**
  * T-i18n - lightweight localization
- * v0.4.1
+ * v0.5.0
  *
  * T-i18n defers to standards to do the hard work of localization. The browser Intl API is use to format
  * dates and numbers. Messages are provided as functions rather than strings, so they can be compiled at build time.

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -1,6 +1,6 @@
 import { IcuReplacements, Messages, MFunc, SetupOptions, AnyReplacements } from "./types";
 import createCachedFormatter, { CachedFormatter, numberFormatOptions, dateTimeFormatOptions} from "./format";
-import { generator, assign, splitReplacements } from "./helpers";
+import { generator, assign, splitAndEscapeReplacements } from "./helpers";
 import parseIcu from "./icu";
 import parseXml from "./xml";
 
@@ -110,7 +110,7 @@ function createT(context: I18n): TFunc {
 		date: context.format.bind(context, "date"),
 		number: context.format.bind(context, "number"),
 		$: <X>(message: string, replacements: AnyReplacements<X> = {}, id?: string): (X | string)[] => {
-			const [icu, xml] = splitReplacements(replacements);
+			const [icu, xml] = splitAndEscapeReplacements(replacements);
 			const translatedMessage = T(message, icu, id);
 			return parseXml(translatedMessage, xml);
 		},

--- a/test/t-i18n.test.ts
+++ b/test/t-i18n.test.ts
@@ -198,6 +198,39 @@ describe("T.$", () => {
         expect(result).to.be.an('array');
         expect(result).to.deep.equal(expected);
     });
+
+    it("should interpret XML entities", () => {
+        const expected = [
+            { name: "a", children: ["A < B"] },
+            ">\"&''",
+        ];
+        const result = T.$(
+            "<a>A &lt; B</a>&gt;&quot;&amp;&#39;&apos;",
+            {
+                a: (...children) => ({ name: "a", children }),
+            }
+        );
+        expect(result).to.be.an('array');
+        expect(result).to.deep.equal(expected);
+    });
+
+    it("should handle unescaped XML entities in ICU replacements", () => {
+        const expected = [
+            { name: "a", children: ["Jo & Joe <3"] },
+            " <script> // John \"Bud\" O'Connor",
+        ];
+        const result = T.$(
+            "<a>{test1}</a> {test2} // {test3}",
+            {
+                a: (...children) => ({ name: "a", children }),
+                test1: "Jo & Joe <3",
+                test2: "<script>",
+                test3: "John \"Bud\" O'Connor",
+            }
+        );
+        expect(result).to.be.an('array');
+        expect(result).to.deep.equal(expected);
+    });
 });
 
 describe("T.date", () => {


### PR DESCRIPTION
When calling `T.$`, we first pass the string through the ICU parser, then through the XML parser. This means that even if the original static string is valid XML, an ICU replacement could contain invalid XML and break the XML parser.

It could be argued that the burden of escaping XML entities falls on the caller, but I think it's simpler to let T handle it.

I added two tests for XML handling. The first one passes without these changes. The second one fails before these changes and passes afterwards.