### PR TITLE
Simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Translate the JSON files:
 Then load the translations, pass them to `T` and set the locale.
 
 ```js
-T.setup({
+T.set({
     locale: "es",
     messages: {
         en: englishJSON,
@@ -94,7 +94,7 @@ T.$(
 
 ## Pluralization and advanced ICU syntax
 
-To get locale-aware pluralization, you should [precompile your translations](https://messageformat.github.io/build/) using an ICU-compliant tool. Then pass the compiled messages to `T.setup` instead of strings.
+To get locale-aware pluralization, you should [precompile your translations](https://messageformat.github.io/build/) using an ICU-compliant tool. Then pass the compiled messages to `T.set` instead of strings.
 
 ```js
 // Pluralization with ICU syntax

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "t-i18n",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t-i18n",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Simple, standards-based localization",
   "author": "Mitch Cohen <mitch.cohen@me.com>",
   "homepage": "https://github.com/agilebits/t-i18n#readme",

--- a/scripts/extract-strings.js
+++ b/scripts/extract-strings.js
@@ -64,7 +64,7 @@ function extractMessages(contents) {
     tCalls.forEach(c => {
         const [message, values, id] = c.arguments;
         const evaluatedMessage = evaluate(message, srcFile);
-        let idText = id ? id.text : index_1.T._i18nInstance.generateId(evaluatedMessage);
+        let idText = id ? id.text : index_1.T.generateId(evaluatedMessage);
         messages[idText] = evaluatedMessage;
     });
     return messages;

--- a/scripts/extract-strings.ts
+++ b/scripts/extract-strings.ts
@@ -15,7 +15,7 @@ const helpers = {
 function evaluate(node: any, src: any): any {
     if (!node) return null;
     if (node.text) return node.text;
-    
+
     const expression = (node as ts.Node).getFullText(src);
 
     // evil eval
@@ -35,18 +35,18 @@ function findMethodCall(objectName: string, methodName: string, src: ts.Node) {
             const call = node as ts.CallExpression;
 
             if (call.expression.kind && call.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
-                
+
                 const methodCall = (call.expression as ts.PropertyAccessExpression),
                         obj = (methodCall.expression as ts.Identifier),
                         method = (methodCall.name as ts.Identifier);
 
                 if (obj.text === objectName && method.text === methodName) {
-                    res.push(node);    
+                    res.push(node);
                 }
             }
         }
 
-        return ts.forEachChild(node, find);    
+        return ts.forEachChild(node, find);
     }
     return res;
 }
@@ -56,7 +56,7 @@ function findFunctionCall(tagName: string, src: ts.Node) {
     find(src);
     function find(node: ts.Node) {
         if (!node) return;
-        
+
         if (node.kind === ts.SyntaxKind.CallExpression) {
             const call = (node as ts.CallExpression),
                 expression = call.expression,
@@ -65,20 +65,20 @@ function findFunctionCall(tagName: string, src: ts.Node) {
                     res.push(node);
                 }
         }
-    
-        return ts.forEachChild(node, find);    
+
+        return ts.forEachChild(node, find);
     }
     return res;
 }
 
 function extractMessages(contents: string) {
-    const srcFile = ts.createSourceFile("file.ts", contents, ts.ScriptTarget.ES2017, false, ts.ScriptKind.TSX);    
+    const srcFile = ts.createSourceFile("file.ts", contents, ts.ScriptTarget.ES2017, false, ts.ScriptKind.TSX);
     const tCalls = [...findFunctionCall("T", srcFile), ...findMethodCall("T", "$", srcFile)];
     let messages = {}
     tCalls.forEach(c => {
         const [message, values, id] = c.arguments;
         const evaluatedMessage = evaluate(message, srcFile);
-        let idText = id ? id.text : T._i18nInstance.generateId(evaluatedMessage);
+        let idText = id ? id.text : T.generateId(evaluatedMessage);
         messages[idText] = evaluatedMessage;
     })
     return messages;

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,58 +1,56 @@
 // Format functions accept both date and number formatters
 export type IntlFormat = Intl.DateTimeFormat|Intl.NumberFormat;
-export type IntlFormatType = (typeof Intl.DateTimeFormat | typeof Intl.NumberFormat )
-export type IntlFormatOptions = Intl.DateTimeFormatOptions | Intl.NumberFormatOptions;
-export type CachedFormatter = (locale: string, formatOptions?: IntlFormatOptions) => IntlFormat;
+export type IntlFormatType<T extends IntlFormat> = T extends Intl.DateTimeFormat ? typeof Intl.DateTimeFormat : typeof Intl.NumberFormat;
+export type IntlFormatOptions<T extends IntlFormat> = T extends Intl.DateTimeFormat ? Intl.DateTimeFormatOptions : Intl.NumberFormatOptions;
+export type CachedFormatter<T extends IntlFormat> = (locale: string, formatOptions?: IntlFormatOptions<T>) => T;
 
-export let dateTimeFormatOptions: {[s: string]: Intl.DateTimeFormatOptions} = {
+export const dateTimeFormats = {
 	short: {
-		month: 'short',
-		day: 'numeric',
+		month: "short",
+		day: "numeric",
 		year: "numeric"
 	},
 	long: {
-		month: 'long',
-		day: 'numeric',
-		year: 'numeric'
+		month: "long",
+		day: "numeric",
+		year: "numeric"
 	},
 	dateTime: {
-		month: 'short',
-		day: 'numeric',
-		year: 'numeric',
-		hour: 'numeric',
-		minute: 'numeric'
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "numeric"
 	}
 };
-dateTimeFormatOptions.default = dateTimeFormatOptions.long;
 
-export let numberFormatOptions: {[s: string]: Intl.NumberFormatOptions} = {
+export const numberFormats = {
 	currency: {
-		style: 'currency',
+		style: "currency",
 		currency: "USD"
 	},
 	decimal: {
-		style: 'decimal'
+		style: "decimal"
 	},
 	percent: {
-		style: 'percent'
+		style: "percent"
 	}
 }
-numberFormatOptions.default = numberFormatOptions.decimal;
 
 // Create cached versions of Intl.DateTimeFormat and Intl.NumberFormat
-export default function createCachedFormatter(intlFormat: (IntlFormatType)): CachedFormatter {
-	let cache:any = {};
+export default function createCachedFormatter<T extends IntlFormat>(intlFormat: IntlFormatType<T>): CachedFormatter<T> {
+	let cache: any = {};
 
-	return function (locale: string, formatOptions?: IntlFormatOptions): IntlFormat {
+	return function (locale: string, formatOptions?: IntlFormatOptions<T>): T {
 		const args = Array.prototype.slice.call(arguments);
 		const id = locale + "-" + JSON.stringify(formatOptions);
 		if (id in cache) return cache[id];
 
-		const formatter: IntlFormat = new (Function.prototype.bind.call(
+		const formatter: T = new (Function.prototype.bind.call(
 			intlFormat, null, ...args
 		));
 
-		cache[id] = formatter;		
+		cache[id] = formatter;
 		return formatter;
 	}
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -39,7 +39,7 @@ export const numberFormats = {
 
 // Create cached versions of Intl.DateTimeFormat and Intl.NumberFormat
 export default function createCachedFormatter<X extends IntlFormat>(intlFormat: IntlFormatType<X>): CachedFormatter<X> {
-	let cache: any = {};
+	const cache: { [key: string]: X } = {};
 
 	return function (locale: string, formatOptions?: IntlFormatOptions<X>): X {
 		const args = Array.prototype.slice.call(arguments);

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,8 +1,8 @@
 // Format functions accept both date and number formatters
 export type IntlFormat = Intl.DateTimeFormat|Intl.NumberFormat;
-export type IntlFormatType<T extends IntlFormat> = T extends Intl.DateTimeFormat ? typeof Intl.DateTimeFormat : typeof Intl.NumberFormat;
-export type IntlFormatOptions<T extends IntlFormat> = T extends Intl.DateTimeFormat ? Intl.DateTimeFormatOptions : Intl.NumberFormatOptions;
-export type CachedFormatter<T extends IntlFormat> = (locale: string, formatOptions?: IntlFormatOptions<T>) => T;
+export type IntlFormatType<X extends IntlFormat> = X extends Intl.DateTimeFormat ? typeof Intl.DateTimeFormat : typeof Intl.NumberFormat;
+export type IntlFormatOptions<X extends IntlFormat> = X extends Intl.DateTimeFormat ? Intl.DateTimeFormatOptions : Intl.NumberFormatOptions;
+export type CachedFormatter<X extends IntlFormat> = (locale: string, formatOptions?: IntlFormatOptions<X>) => X;
 
 export const dateTimeFormats = {
 	short: {
@@ -38,15 +38,15 @@ export const numberFormats = {
 }
 
 // Create cached versions of Intl.DateTimeFormat and Intl.NumberFormat
-export default function createCachedFormatter<T extends IntlFormat>(intlFormat: IntlFormatType<T>): CachedFormatter<T> {
+export default function createCachedFormatter<X extends IntlFormat>(intlFormat: IntlFormatType<X>): CachedFormatter<X> {
 	let cache: any = {};
 
-	return function (locale: string, formatOptions?: IntlFormatOptions<T>): T {
+	return function (locale: string, formatOptions?: IntlFormatOptions<X>): X {
 		const args = Array.prototype.slice.call(arguments);
 		const id = locale + "-" + JSON.stringify(formatOptions);
 		if (id in cache) return cache[id];
 
-		const formatter: T = new (Function.prototype.bind.call(
+		const formatter: X = new (Function.prototype.bind.call(
 			intlFormat, null, ...args
 		));
 

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -10,6 +10,10 @@ import parseXml from "./xml";
  *
  * T-i18n defers to standards to do the hard work of localization. The browser Intl API is use to format
  * dates and numbers. Messages are provided as functions rather than strings, so they can be compiled at build time.
+ *
+ *
+ * Made by Mitch Cohen and Rob Yoder
+ * First released on July 31, 2017
  */
 
 export interface TFunc {

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -18,13 +18,13 @@ import parseXml from "./xml";
 
 export interface TFunc {
 	(message: string, replacements?: IcuReplacements, id?: string): string;
+	$: <X>(message: string, replacements?: AnyReplacements<X>, id?: string) => (X | string)[];
+	date: (value: Date | number, formatName?: keyof typeof dateTimeFormats, locale?: string) => string;
 	generateId: (message: string) => string;
 	locale: () => string;
 	lookup: (id: string, replacements?: IcuReplacements, defaultMessage?:string) => string
-	setup: (options?: SetupOptions) => any;
-	date: (value: Date | number, formatName?: keyof typeof dateTimeFormats, locale?: string) => string;
 	number: (value: number, formatName?: keyof typeof numberFormats, locale?: string) => string;
-	$: <X>(message: string, replacements?: AnyReplacements<X>, id?: string) => (X | string)[];
+	setup: (options?: SetupOptions) => any;
 }
 
 const defaultLanguage = "en";

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -22,8 +22,8 @@ export interface TFunc {
 	locale: () => string;
 	lookup: (id: string, replacements?: IcuReplacements, defaultMessage?:string) => string
 	setup: (options?: SetupOptions) => any;
-	date: (value: any, formatName?: keyof typeof dateTimeFormats, locale?: string) => string;
-	number: (value: any, formatName?: keyof typeof numberFormats, locale?: string) => string;
+	date: (value: Date | number, formatName?: keyof typeof dateTimeFormats, locale?: string) => string;
+	number: (value: number, formatName?: keyof typeof numberFormats, locale?: string) => string;
 	$: <X>(message: string, replacements?: AnyReplacements<X>, id?: string) => (X | string)[];
 }
 
@@ -59,7 +59,7 @@ export const makeT = (): TFunc => {
 		return { messages, locale, idGenerator };
 	}
 
-	const date = (value: Date, style: keyof typeof dateTimeFormats = "long", dateLocale = locale) => {
+	const date = (value: Date | number, style: keyof typeof dateTimeFormats = "long", dateLocale = locale) => {
 		const format = dateTimeFormats[style] || dateTimeFormats.long;
 		return dateFormatter(dateLocale, format).format(value);
 	}

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -1,4 +1,4 @@
-import { IcuReplacements, Messages, MFunc, SetupOptions, AnyReplacements } from "./types";
+import { IcuReplacements, Messages, MFunc, Config, AnyReplacements } from "./types";
 import createCachedFormatter, { numberFormats, dateTimeFormats} from "./format";
 import { generator, assign, splitAndEscapeReplacements } from "./helpers";
 import parseIcu from "./icu";
@@ -24,7 +24,7 @@ export interface TFunc {
 	locale: () => string;
 	lookup: (id: string, replacements?: IcuReplacements, defaultMessage?:string) => string
 	number: (value: number, formatName?: keyof typeof numberFormats, locale?: string) => string;
-	setup: (options?: SetupOptions) => any;
+	set: (options?: Partial<Config>) => Config;
 }
 
 const defaultLanguage = "en";
@@ -51,7 +51,7 @@ export const makeT = (): TFunc => {
 	let locale = defaultLanguage;
 	let idGenerator = generator.hyphens;
 
-	const setup = (options: SetupOptions = {}): SetupOptions => {
+	const set = (options: Partial<Config> = {}): Config => {
 		messages = options.messages || messages;
 		locale = options.locale || locale;
 		idGenerator = options.idGenerator || idGenerator;
@@ -97,7 +97,7 @@ export const makeT = (): TFunc => {
 		locale: () => locale,
 		lookup,
 		number,
-		setup,
+		set,
 	};
 
 	return assign(T, properties);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,10 +22,10 @@ export interface Messages {
 	[s: string]: {[s: string]: string|MFunc}
 }
 
-export interface SetupOptions {
-	messages?: Messages;
-	locale?: string;
-	idGenerator?: (message: string) => string;
+export interface Config {
+	messages: Messages;
+	locale: string;
+	idGenerator: (message: string) => string;
 }
 
 export type Mutable<X> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,6 @@ export interface SetupOptions {
 	messages?: Messages;
 	locale?: string;
 	idGenerator?: (message: string) => string;
-	compiler?: Compiler;
 }
 
 export type Mutable<X> = {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,45 +1,45 @@
 /// <reference path="../node_modules/@types/mocha/index.d.ts" />
 
 import { expect } from "chai";
-import createCachedFormatter, {dateTimeFormatOptions, numberFormatOptions} from "../src/format";
+import createCachedFormatter from "../src/format";
 
 describe("createCachedFormatter", () => {
     it("should create a date formatter", () => {
         const options =  {day: "numeric", month: "long", year: "numeric"};
         const date = new Date(2017, 8, 1);
-        const formatter = createCachedFormatter(Intl.DateTimeFormat);
-        
+        const formatter = createCachedFormatter<Intl.DateTimeFormat>(Intl.DateTimeFormat);
+
         const expected = new Intl.DateTimeFormat("en", options).format(date);
-        const result = (<Intl.DateTimeFormat>formatter("en", options)).format(date);
-        
+        const result = formatter("en", options).format(date);
+
         expect (result).to.equal(expected);
     });
 
     it("should cache a new date formatter with the same settings", () => {
-        const formatter = createCachedFormatter(Intl.DateTimeFormat); 
+        const formatter = createCachedFormatter(Intl.DateTimeFormat);
         const a = formatter("en", {month: "long", year: "2-digit"});
         const b = formatter("en", {month: "long", year: "2-digit"});
-        
+
         const result = (a === b);
-        
+
         expect (result).to.equal(true);
     });
 
     it("should create a number formatter", () => {
-        const formatter = createCachedFormatter(Intl.NumberFormat);
-    
+        const formatter = createCachedFormatter<Intl.NumberFormat>(Intl.NumberFormat);
+
         const expected = new Intl.NumberFormat("es").format(2.3);
-        const result = (<Intl.NumberFormat>formatter("es")).format(2.3);
+        const result = formatter("es").format(2.3);
         expect (result).to.equal(expected);
     });
 
     it("should cache a new number formatter with the same settings", () => {
-        const formatter = createCachedFormatter(Intl.NumberFormat);        
+        const formatter = createCachedFormatter(Intl.NumberFormat);
         const a = formatter("ja");
         const b = formatter("ja");
-        
+
         const result = (a === b);
-        
+
         expect (result).to.equal(true);
     });
 });

--- a/test/t-i18n.test.ts
+++ b/test/t-i18n.test.ts
@@ -47,7 +47,7 @@ describe("T", () => {
             "not-compiled": "No compilado",
         }
     }
-    T.setup({
+    T.set({
         locale: "es",
         messages: messages,
         idGenerator: generator.hyphens
@@ -242,19 +242,19 @@ describe("T.locale", () => {
     });
 
     it("should return updated locale", () => {
-        T.setup({ locale: "it" });
+        T.set({ locale: "it" });
         expect(T.locale()).to.equal("it");
     });
 
     it("should return twice updated locale", () => {
-        T.setup({ locale: "de" });
+        T.set({ locale: "de" });
         expect(T.locale()).to.equal("de");
     });
 });
 
 describe("T.date", () => {
     const T = makeT();
-    T.setup({
+    T.set({
         locale: "it"
     });
 
@@ -285,7 +285,7 @@ describe("T.date", () => {
 
 describe("T.number", () => {
     const T = makeT();
-    T.setup({
+    T.set({
         locale: "he"
     });
 

--- a/test/t-i18n.test.ts
+++ b/test/t-i18n.test.ts
@@ -1,14 +1,14 @@
 /// <reference path="../node_modules/@types/mocha/index.d.ts" />
 
 import { expect } from "chai";
-import {T, makeT} from "../src/index";
-import {Plural, generator} from "../src/helpers";
-import {dateTimeFormatOptions, numberFormatOptions} from "../src/format";
+import { makeT } from "../src/index";
+import { Plural, generator } from "../src/helpers";
+import { dateTimeFormats, numberFormats } from "../src/format";
 
 // Shim for DOM XML parser
 import { DOMParser } from "xmldom";
-global['DOMParser'] = DOMParser;
-global['Node'] = {
+global["DOMParser"] = DOMParser;
+global["Node"] = {
     ELEMENT_NODE: 1
 };
 
@@ -30,7 +30,7 @@ describe("Plural", () => {
 });
 
 describe("T", () => {
-    const T = createI18n();
+    const T = makeT();
     const messages = {
         en: {
             "Hello--world": () => "Hello, world",
@@ -86,11 +86,12 @@ describe("T", () => {
     it("should compile a string message with replacements", () => {
         const expected = "Howdy, Mitch";
         const result = T("Howdy, {name}", {name: "Mitch"});
+        expect(result).to.equal(expected);
     });
 });
 
 describe("T.$", () => {
-    const T = createI18n();
+    const T = makeT();
 
     it("should replace an XML tag with the named function and pass inner string as children", () => {
         const expected = ["Hi, ", { href: "#", children: ["Joe"] }, "!"];
@@ -101,7 +102,7 @@ describe("T.$", () => {
                 name: "Joe"
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -123,7 +124,7 @@ describe("T.$", () => {
                 bold: (...children) => ({ name: "strong", children }),
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -145,7 +146,7 @@ describe("T.$", () => {
                 bold: (...children) => ({ name: "strong", children }),
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -158,7 +159,7 @@ describe("T.$", () => {
                 b: () => ({ text: "B" })
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -174,7 +175,7 @@ describe("T.$", () => {
                 format: (...children) => ({ name: "format", children })
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -183,7 +184,7 @@ describe("T.$", () => {
         const result = T.$(
             "Test: <!-- comment -->",
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -195,7 +196,7 @@ describe("T.$", () => {
                 wrap: (...children) => ({ name: "wrap", children })
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -210,7 +211,7 @@ describe("T.$", () => {
                 a: (...children) => ({ name: "a", children }),
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 
@@ -228,36 +229,54 @@ describe("T.$", () => {
                 test3: "John \"Bud\" O'Connor",
             }
         );
-        expect(result).to.be.an('array');
+        expect(result).to.be.an("array");
         expect(result).to.deep.equal(expected);
     });
 });
 
+describe("T.locale", () => {
+    const T = makeT();
+
+    it("should have default locale", () => {
+        expect(T.locale()).to.equal("en");
+    });
+
+    it("should return updated locale", () => {
+        T.setup({ locale: "it" });
+        expect(T.locale()).to.equal("it");
+    });
+
+    it("should return twice updated locale", () => {
+        T.setup({ locale: "de" });
+        expect(T.locale()).to.equal("de");
+    });
+});
+
 describe("T.date", () => {
-    const T = createI18n();
+    const T = makeT();
     T.setup({
         locale: "it"
     });
 
     it("should print a localized date using the default format", () => {
         const date = Date.now();
-        const expected = new Intl.DateTimeFormat("it", dateTimeFormatOptions.default).format(date);
-        [null, 'default', 'nonexistent'].forEach(format => {
-            const result = T.date(date, format);
+        const expected = new Intl.DateTimeFormat("it", dateTimeFormats.long).format(date);
+        [null, "long", "nonexistent"].forEach((format) => {
+            const result = T.date(date, format as any);
             expect(result).to.equal(expected);
         });
     });
 
     it("should print a localized 'short' date", () => {
         const date = Date.now();
-        const expected = new Intl.DateTimeFormat("it", dateTimeFormatOptions.short).format(date);
+        const expected = new Intl.DateTimeFormat("it", dateTimeFormats.short).format(date);
         const result = T.date(date, "short");
         expect(result).to.equal(expected);
     });
 
     it("should print a date in the provided locale", () => {
         const date = Date.now();
-        const expected = new Intl.DateTimeFormat("ru", dateTimeFormatOptions.default).format(date);
+        const expected = new Intl.DateTimeFormat("ru", dateTimeFormats.long).format(date);
         const result = T.date(date, null, "ru");
         expect(result).to.equal(expected);
     });
@@ -265,36 +284,31 @@ describe("T.date", () => {
 
 
 describe("T.number", () => {
-    const T = createI18n();
+    const T = makeT();
     T.setup({
         locale: "he"
     });
 
     it("should print a localized number using the default (decimal) format", () => {
         const number = 15;
-        const expected = new Intl.NumberFormat("he", numberFormatOptions.default).format(number);
-        [null, 'default', 'nonexistent'].forEach(format => {
-            const result = T.number(number, format);
+        const expected = new Intl.NumberFormat("he", numberFormats.decimal).format(number);
+        [null, "decimal", "nonexistent"].forEach((format) => {
+            const result = T.number(number, format as any);
             expect(result).to.equal(expected);
         });
     });
 
     it("should print a localized currency value in USD", () => {
         const number = 10.5;
-        const expected = new Intl.NumberFormat("he", numberFormatOptions.currency).format(number);
+        const expected = new Intl.NumberFormat("he", numberFormats.currency).format(number);
         const result = T.number(number, "currency");
         expect(result).to.equal(expected);
     });
 
     it("should print a number in the provided locale", () => {
         const number = 25;
-        const expected = new Intl.NumberFormat("ko", numberFormatOptions.default).format(number);
+        const expected = new Intl.NumberFormat("ko", numberFormats.decimal).format(number);
         const result = T.number(number, null, "ko");
         expect(result).to.equal(expected);
     });
 });
-
-
-function createI18n() {
-    return makeT();
-}


### PR DESCRIPTION
I started out wanting a way to get the locale that looked less hacky than `T._i18nInstance.locale`. It's pretty easy to just add a `locale()` method to `T` that returns that value. But as I looked at the code I realized the whole `I18n` class and instance weren't really necessary, and I could simplify a lot by removing them. So I did.

All of the tests pass. The only things that are not backward compatible are references to `setup` (now called `set`) , `_i18nInstance`, and some stricter TS types. But those are sufficient to bump the version to 0.6.0.