### PR TITLE
Workaround to fix Intl.DateTimeFormat crashing Chrome

### DIFF
--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -54,18 +54,32 @@ const makeIntlFormatters = (locale: () => string): IntlFormatters => {
 		return { date: error, number: error };
 	}
 
-    Date.prototype.toLocaleString = Date.prototype.toString;
-    Date.prototype.toLocaleTimeString = Date.prototype.toTimeString;
-    const delegate = Intl.DateTimeFormat;
-    function DateTimeFormat(): typeof Intl.DateTimeFormat {
-      const args = Array.prototype.slice.apply(arguments);
-      args[0] = args[0] || "en-US";
-      args[1] = args[1] || {};
-	  args[1].timeZone = args[1].timeZone || "America/Toronto";
-      return delegate.apply(this, args);
-    }
-	DateTimeFormat.prototype = delegate.prototype;
-    Intl.DateTimeFormat = DateTimeFormat;
+	// HACK: See https://bugs.chromium.org/p/chromium/issues/detail?id=811403
+	const getDateTimeFormat = () => {
+		const delegate = Intl.DateTimeFormat;
+		function DateTimeFormat(this: any) {
+			const args = Array.prototype.slice.apply(arguments);
+			args[0] = args[0] || "en-US";
+			args[1] = args[1] || {};
+			args[1].timeZone = args[1].timeZone || "America/Toronto";
+			return delegate.apply(this, args);
+		}
+		DateTimeFormat.prototype = delegate.prototype;
+		return DateTimeFormat;
+	}
+
+	try {
+		Intl.DateTimeFormat();
+		(new Date()).toLocaleString();
+		(new Date()).toLocaleDateString();
+		(new Date()).toLocaleTimeString();
+	} catch (err) {
+		Date.prototype.toLocaleString = Date.prototype.toString;
+		Date.prototype.toLocaleDateString = Date.prototype.toDateString;
+		Date.prototype.toLocaleTimeString = Date.prototype.toTimeString;
+		Intl.DateTimeFormat = getDateTimeFormat() as any;
+	}
+	// HACK: end
 
 	const dateFormatter = createCachedFormatter<Intl.DateTimeFormat>(Intl.DateTimeFormat);
 	const numberFormatter = createCachedFormatter<Intl.NumberFormat>(Intl.NumberFormat);

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -54,6 +54,19 @@ const makeIntlFormatters = (locale: () => string): IntlFormatters => {
 		return { date: error, number: error };
 	}
 
+    Date.prototype.toLocaleString = Date.prototype.toString;
+    Date.prototype.toLocaleTimeString = Date.prototype.toTimeString;
+    const delegate = Intl.DateTimeFormat;
+    function DateTimeFormat(): typeof Intl.DateTimeFormat {
+      const args = Array.prototype.slice.apply(arguments);
+      args[0] = args[0] || "en-US";
+      args[1] = args[1] || {};
+	  args[1].timeZone = args[1].timeZone || "America/Toronto";
+      return delegate.apply(this, args);
+    }
+	DateTimeFormat.prototype = delegate.prototype;
+    Intl.DateTimeFormat = DateTimeFormat;
+
 	const dateFormatter = createCachedFormatter<Intl.DateTimeFormat>(Intl.DateTimeFormat);
 	const numberFormatter = createCachedFormatter<Intl.NumberFormat>(Intl.NumberFormat);
 


### PR DESCRIPTION
Until Chrome fixes the issue: https://bugs.chromium.org/p/chromium/issues/detail?id=811403

This workaround should make a lot of customers happy.