### PR TITLE
Tell Rollup where to get ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t-i18n",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Simple, standards-based localization",
   "author": "Mitch Cohen <mitch.cohen@me.com>",
   "homepage": "https://github.com/agilebits/t-i18n#readme",
@@ -10,6 +10,7 @@
   },
   "license": "MIT",
   "main": "dist/index.js",
+  "module": "dist/es6/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "cd dist/; rm -rf *",


### PR DESCRIPTION
Rollup thinks there are no ES modules here. We're building them, just not pointing to them.