### PR TITLE
Switch to maintained xmldom fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,12 @@
         "@types/chai": "^4.2.7",
         "@types/mocha": "^10.0.6",
         "@types/node": "^12.12.21",
+        "@xmldom/xmldom": "^0.8.10",
         "chai": "^4.2.0",
         "glob": "^7.1.2",
         "mocha": "^10.2.0",
         "ts-node": "^8.5.4",
-        "typescript": "^3.7.3",
-        "xmldom": "^0.5.0"
+        "typescript": "^3.7.3"
       }
     },
     "node_modules/@types/chai": {
@@ -43,6 +43,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
       "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
       "dev": true
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -1070,15 +1079,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "node_modules/xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mocha": "^10.2.0",
     "ts-node": "^8.5.4",
     "typescript": "^3.7.3",
-    "xmldom": "^0.5.0"
+    "@xmldom/xmldom": "^0.8.10"
   },
   "dependencies": {
     "minimist": "^1.2.5"


### PR DESCRIPTION
This switches us to [a maintained XMLdom fork](https://www.npmjs.com/package/@xmldom/xmldom) for future maintenance and to address a vulnerability alert.