### PR TITLE
Fix xmldom import and get-func-name vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -447,9 +447,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"

--- a/test/t-i18n.test.ts
+++ b/test/t-i18n.test.ts
@@ -6,7 +6,7 @@ import { dateTimeFormats, numberFormats } from "../src/format";
 import { BasicTFunc, TFunc } from "../src/t-i18n";
 
 // Shim for DOM XML parser
-import { DOMParser } from "xmldom";
+import { DOMParser } from "@xmldom/xmldom";
 global["DOMParser"] = DOMParser;
 global["Node"] = {
     ELEMENT_NODE: 1


### PR DESCRIPTION
I missed the crucial `npm install` step when testing #36, so the build is currently broken. When I did that install, npm alerted me of another vulnerability that could be addressed with `npm audit fix`, so I went ahead and did that too.