### PR TITLE
Create error versions of T

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "t-i18n",
-	"version": "0.6.5",
+	"version": "0.6.6",
 	"description": "Simple, standards-based localization",
 	"author": "Mitch Cohen <mitch.cohen@me.com>",
 	"homepage": "https://github.com/agilebits/t-i18n#readme",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { Plural, generator } from "./helpers";
 
-export { default as T, makeBasicT, makeT } from "./t-i18n";
+export {
+	default as T,
+	makeBasicT,
+	makeT,
+	makeErrorBasicT,
+	makeErrorT,
+} from "./t-i18n";

--- a/src/t-i18n.ts
+++ b/src/t-i18n.ts
@@ -203,5 +203,47 @@ export const makeT = (): TFunc => {
 	return assign(T, formatters);
 };
 
+/**
+ * Create a version of `T` that only errors.
+ *
+ * This is useful if you need to enforce a certain way of loading strings,
+ * such as with React's Context Providers.
+ */
+export const makeErrorBasicT = (message: string): BasicTFunc => {
+	const errorFn = () => {
+		throw new Error(message);
+	};
+
+	return assign(errorFn, {
+		$: errorFn,
+		generateId: errorFn,
+		locale: errorFn,
+		lookup: errorFn,
+		set: errorFn,
+	});
+};
+
+/**
+ * Create a version of `T` that only errors.
+ *
+ * This is useful if you need to enforce a certain way of loading strings,
+ * such as with React's Context Providers.
+ */
+export const makeErrorT = (message: string): TFunc => {
+	const errorFn = () => {
+		throw new Error(message);
+	};
+
+	return assign(errorFn, {
+		$: errorFn,
+		generateId: errorFn,
+		locale: errorFn,
+		lookup: errorFn,
+		set: errorFn,
+		date: errorFn,
+		number: errorFn,
+	});
+};
+
 // singleton (T)
 export default makeT();

--- a/test/t-i18n.test.ts
+++ b/test/t-i18n.test.ts
@@ -1,7 +1,15 @@
 /// <reference path="../node_modules/@types/mocha/index.d.ts" />
 
 import { expect } from "chai";
-import { makeBasicT, makeT, Plural, generator, T as globalT } from "../src";
+import {
+	makeBasicT,
+	makeErrorBasicT,
+	makeErrorT,
+	makeT,
+	Plural,
+	generator,
+	T as globalT,
+} from "../src";
 import { dateTimeFormats, numberFormats } from "../src/format";
 import { BasicTFunc, TFunc } from "../src/t-i18n";
 
@@ -323,5 +331,35 @@ describe("T.number", () => {
 		);
 		const result = T.number(number, undefined, "ko");
 		expect(result).to.equal(expected);
+	});
+});
+
+describe("makeErrorBasicT", () => {
+	it("should produce a T that errors on every function call", () => {
+		const message = "LocaleProvider is not mounted";
+		const T = makeErrorBasicT(message);
+
+		expect(() => T("test")).to.throw(message);
+		expect(() => T.$("test")).to.throw(message);
+		expect(() => T.generateId("test")).to.throw(message);
+		expect(() => T.locale()).to.throw(message);
+		expect(() => T.lookup("abc")).to.throw(message);
+		expect(() => T.set({ locale: "en" })).to.throw(message);
+	});
+});
+
+describe("makeErrorT", () => {
+	it("should produce a T that errors on every function call", () => {
+		const message = "LocaleProvider is not mounted";
+		const T = makeErrorT(message);
+
+		expect(() => T("test")).to.throw(message);
+		expect(() => T.$("test")).to.throw(message);
+		expect(() => T.generateId("test")).to.throw(message);
+		expect(() => T.locale()).to.throw(message);
+		expect(() => T.lookup("abc")).to.throw(message);
+		expect(() => T.set({ locale: "en" })).to.throw(message);
+		expect(() => T.date(new Date())).to.throw(message);
+		expect(() => T.number(12345)).to.throw(message);
 	});
 });


### PR DESCRIPTION
In B5X, we had an issue where there were two options for Locale providers and one file used the wrong one, leading to a perplexing issue with partial translations. If the T function that initialized the empty context had errored instead of falling back to something halfway useful, the problem would have been a lot clearer.

Here I provide functions to make that kind of setup easy so that consumers don't need to maintain them.

Resolves #45 